### PR TITLE
Remove extraneous echo

### DIFF
--- a/session/gnome-session-i3
+++ b/session/gnome-session-i3
@@ -6,4 +6,4 @@ if [ $HASBUILTIN -eq 0 ]; then
 else
     BUILTINARG=""
 fi
-echo env GNOME_SHELL_SESSION_MODE=classic gnome-session $BUILTINARG --session i3-gnome "$@"
+env GNOME_SHELL_SESSION_MODE=classic gnome-session $BUILTINARG --session i3-gnome "$@"


### PR DESCRIPTION
In #53 an extraneous echo prefix was included, thereby breaking the gnome-session command.  This is removed in this commit.