### PR TITLE
don't set GNOME_SHELL_SESSION_MODE env variable

### DIFF
--- a/session/gnome-session-i3
+++ b/session/gnome-session-i3
@@ -6,4 +6,4 @@ if [ $HASBUILTIN -eq 0 ]; then
 else
     BUILTINARG=""
 fi
-env GNOME_SHELL_SESSION_MODE=classic gnome-session $BUILTINARG --session i3-gnome "$@"
+gnome-session $BUILTINARG --session i3-gnome "$@"


### PR DESCRIPTION
This was added in 88f1b7bbf7e9e4168ca64371e819fbc841257c42 commit without any explanation why it is needed!

This environment variable is used by gnome-shell which is not used with i3-gnome session.