### PR TITLE
feat(i3-gnome): add support for merging .Xresources before i3 starts

### DIFF
--- a/session/i3-gnome
+++ b/session/i3-gnome
@@ -5,6 +5,11 @@ test -n "$DESKTOP_AUTOSTART_ID" && {
     dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:i3-gnome" "string:$DESKTOP_AUTOSTART_ID"
 }
 
+# Support for merging .Xresources
+test -e $HOME/.Xresources && {
+    xrdb -merge $HOME/.Xresources
+}
+
 i3
 
 # Logout process.


### PR DESCRIPTION
Hi there,

This add support for merging `.Xresources` before `i3` starts - unfortunately, on Ubuntu 20.04 with `i3-gnome` the login manager (`gdm`) doesn't do it for whatever reasons. Therefore settings like this just don't take effect:

```
Xft.dpi: 192
Xcursor.size: 48
```

It is possible to `exec xrdb` from `i3` config, but then the settings get applies too late, after `i3` has already started, and `i3` has to be restarted to function correctly.

Therefore I have added merging just before `i3` starts here - it shouldn't have any negative side effects, but if anyone happens to know why `gdm3` doesn't merge on stock Ubuntu 20.04 and knows of better way, please do let me know.

All the best,
Yury