### PR TITLE
readme: use HTTPS Git URL instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Allows you to use i3wm with GNOME 3 Session infrastructure.
 
 ## Installation using make
 Using `make`:
-* `git clone git@github.com:i3-gnome/i3-gnome.git`.
+* `git clone https://github.com/i3-gnome/i3-gnome.git`
 * `cd i3-gnome`
 * `sudo make install`
 


### PR DESCRIPTION
Not all users have (or are aware of) how to set up SSH keys. Using HTTPS
is easier since it does not require extra steps to use. Even for users
who have keys, it avoids possibly needing to enter a passphrase.

Also, convert the `make` directions to a fenced code block so that all
lines can be copied more easily.